### PR TITLE
[codex] fix snmp-exporter config for latest image

### DIFF
--- a/zabbix+librenms+grafana/snmp.yml
+++ b/zabbix+librenms+grafana/snmp.yml
@@ -1,3 +1,8 @@
+auths:
+  global:
+    version: 2
+    community: global
+
 modules:
   if_mib:
     walk:
@@ -8,5 +13,3 @@ modules:
     max_repetitions: 25
     retries: 3
     timeout: 10s
-    auth:
-      community: global


### PR DESCRIPTION
## What changed

- Update `snmp.yml` to the current snmp_exporter `auths:` format.
- Keep the existing `global` SNMP v2 community behavior used by the compose stack.

## Why

`prom/snmp-exporter:latest` fails to start with the old per-module `auth:` block. When the exporter restarts, Prometheus cannot resolve or scrape `snmp-exporter`, causing firewall SNMP targets to stay down and ISP traffic panels to show No data.

The current firewall SNMP walk works from the LibreNMS container, so the issue is the exporter container configuration, not the firewall SNMP settings.

## Validation

- Matched the current upstream snmp_exporter config shape where URL `auth` values refer to named entries under `auths`.
- Could not run Docker locally because this Windows workspace does not have Docker installed.