### PR TITLE
bigscreen: remove trailing moving average from ping trend charts

### DIFF
--- a/zabbix+librenms+grafana/bigscreen/app.js
+++ b/zabbix+librenms+grafana/bigscreen/app.js
@@ -861,7 +861,7 @@
 
   function tournamentTrendQuery(page) {
     const selector = tournamentSelector(page);
-    return `avg by (team,seat) (avg_over_time(probe_icmp_duration_seconds{${selector},phase="rtt"}[3m]))`;
+    return `avg by (team,seat) (probe_icmp_duration_seconds{${selector},phase="rtt"})`;
   }
 
   function playerLatencySnapshotQuery(selector) {
@@ -877,8 +877,7 @@
       axisFormatter: formatPingText,
       valueFormatter: formatPingText,
       minMax: 0.005,
-      smooth: true,
-      smoothWindow: 5
+      smooth: true
     };
   }
 
@@ -1415,7 +1414,6 @@
         valueFormatter: formatPingText,
         minMax: 0.005,
         smooth: true,
-        smoothWindow: 5,
         legend: "bottom"
       });
       renderLineChart("evidenceSuccessChart", successSeries.map((series) => ({ ...series, color: "#73d17a" })), {


### PR DESCRIPTION
Remove avg_over_time([3m]) from tournamentTrendQuery and drop
smoothWindow:5 from lineChartOptions and evidenceLatencyChart so that
ping spikes appear and recover immediately, matching Grafana's display
of the raw probe_icmp_duration_seconds metric.

https://claude.ai/code/session_01BvcmPxzKx6sRsYV1P2UDS3